### PR TITLE
FileReadFailure exception class fix

### DIFF
--- a/src/include/vuh/error.h
+++ b/src/include/vuh/error.h
@@ -12,7 +12,7 @@ namespace vuh {
 	};
 
 	/// Exception indicating failure to read a file.
-	class FileReadFailure: std::runtime_error {
+	class FileReadFailure: public std::runtime_error {
 	public:
 		FileReadFailure(const std::string& message);
 		FileReadFailure(const char* message);


### PR DESCRIPTION
Class has to be declared as public otherwise a C4670 warning is triggered.