### PR TITLE
Fix Android NDK 18.1.5063045 complie error

### DIFF
--- a/src/instance.cpp
+++ b/src/instance.cpp
@@ -71,7 +71,7 @@ namespace {
 	}
 
 	/// Default debug reporter used when user did not care to provide his own.
-	static auto debugReporter(
+	static auto VKAPI_ATTR debugReporter(
 	      VkDebugReportFlagsEXT , VkDebugReportObjectTypeEXT, uint64_t, size_t, int32_t
 	      , const char*                pLayerPrefix
 	      , const char*                pMessage


### PR DESCRIPTION
[ 20%] Building CXX object src/CMakeFiles/vuh.dir/instance.cpp.o
vuh/src/instance.cpp:127:33: error: incompatible operand
types ('vuh::debug_reporter_t' (aka 'unsigned int (*)(unsigned int,
VkDebugReportObjectTypeEXT, unsigned long long, unsigned int, int, const
char *, const char *, void *) __attribute__((pcs("aapcs-vfp")))') and
'auto (*)(VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, uint64_t,
size_t, int32_t, const char *, const char *, void *) -> VkBool32' (aka
'auto (*)(unsigned int, VkDebugReportObjectTypeEXT, unsigned long long,
unsigned int, int, const char *, const char *, void *) -> unsigned int'))
, _reporter(report_callback ? report_callback : debugReporter)
^ ~~~~~~~~~~~~~~~ ~~~~~~~~~~~~~
vuh/src/instance.cpp:128:49: warning: field '_reporter' is
uninitialized when used here [-Wuninitialized]
, _reporter_cbk(registerReporter(_instance, _reporter))
^
1 warning and 1 error generated.
make[2]: *** [src/CMakeFiles/vuh.dir/instance.cpp.o] Error 1
make[1]: *** [src/CMakeFiles/vuh.dir/all] Error 2
make: *** [all] Error 2

use command

cmake .. \
-DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake \
-DANDROID_ABI="armeabi-v7a" \
-DCMAKE_BUILD_TYPE=Release \
-DANDROID_STL=c++_static \
-DANDROID_NATIVE_API_LEVEL=android-24 \
-DANDROID_TOOLCHAIN=clang \
-DVUH_BUILD_TESTS=OFF \
-DVUH_BUILD_DOCS=OFF \
-DVUH_BUILD_EXAMPLES=OFF \
-DCMAKE_CXX_FLAGS="-DVK_USE_PLATFORM_ANDROID_KHR=1 -DVULKAN_HPP_TYPESAFE_CONVERSION=1 -I$ANDROID_NDK_HOME/sources/third_party/vulkan/src/include/"

from "vk_platform.h" VKAPI_ATTR is __attribute__((pcs("aapcs-vfp")))

#if defined(_WIN32)
// On Windows, Vulkan commands use the stdcall convention
#define VKAPI_ATTR
#define VKAPI_CALL __stdcall
#define VKAPI_PTR VKAPI_CALL
#elif defined(__ANDROID__) && defined(__ARM_ARCH) && __ARM_ARCH < 7
#error "Vulkan isn't supported for the 'armeabi' NDK ABI"
#elif defined(__ANDROID__) && defined(__ARM_ARCH) && __ARM_ARCH >= 7 && defined(__ARM_32BIT_STATE)
// On Android 32-bit ARM targets, Vulkan functions use the "hardfloat"
// calling convention, i.e. float parameters are passed in registers. This
// is true even if the rest of the application passes floats on the stack,
// as it does by default when compiling for the armeabi-v7a NDK ABI.
#define VKAPI_ATTR __attribute__((pcs("aapcs-vfp")))
#define VKAPI_CALL
#define VKAPI_PTR VKAPI_ATTR
#else
// On other platforms, use the default calling convention
#define VKAPI_ATTR
#define VKAPI_CALL
#define VKAPI_PTR
#endif