### PR TITLE
it is very important please merge this to master too.

### DIFF
--- a/doc/examples/vuhAndroid/app/CMakeLists.txt
+++ b/doc/examples/vuhAndroid/app/CMakeLists.txt
@@ -25,7 +25,9 @@ add_library(vulkan SHARED IMPORTED)
 set_target_properties(vulkan PROPERTIES IMPORTED_LOCATION ${Vulkan_LIBRARIES})
 
 # for vuh
-add_definitions(-DVK_USE_PLATFORM_ANDROID_KHR=1 -DVULKAN_HPP_TYPESAFE_CONVERSION=1)
+# do'nt define VULKAN_HPP_TYPESAFE_CONVERSION it's not safe on 32bits system
+# from vulkan.hpp "32-bit vulkan is not typesafe for handles, so don't allow copy constructors on this platform by default."
+add_definitions(-DVK_USE_PLATFORM_ANDROID_KHR=1)
 SET(VUH_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../../)
 SET(VUH_BUILD_TESTS OFF)
 SET(VUH_BUILD_DOCS OFF)

--- a/src/instance.cpp
+++ b/src/instance.cpp
@@ -111,7 +111,11 @@ namespace {
 		auto createFN = PFN_vkCreateDebugReportCallbackEXT(
 		                                  instance.getProcAddr("vkCreateDebugReportCallbackEXT"));
 		if(createFN){
-			createFN(instance, &createInfo, nullptr, &ret);
+            //https://github.com/KhronosGroup/Vulkan-Hpp/issues/70
+            // 32-bit vulkan is not typesafe for handles, so don't allow copy constructors on this platform by default.
+            // VULKAN_HPP_TYPESAFE_CONVERSION commit
+            // we use vk::Instance's  VkInstance() operator get right handle value
+			createFN(VkInstance(instance), &createInfo, nullptr, &ret);
 		}
 		return ret;
 	}
@@ -160,11 +164,15 @@ namespace vuh {
 	auto Instance::clear() noexcept-> void {
 		if(_instance){
 			if(_reporter_cbk){// unregister callback.
+                //https://github.com/KhronosGroup/Vulkan-Hpp/issues/70
+                // 32-bit vulkan is not typesafe for handles, so don't allow copy constructors on this platform by default.
+                // VULKAN_HPP_TYPESAFE_CONVERSION commit
+                // we use vk::Instance's  VkInstance() operator get right handle value
 				auto destroyFn = PFN_vkDestroyDebugReportCallbackEXT(
-				                    vkGetInstanceProcAddr(_instance, "vkDestroyDebugReportCallbackEXT")
+				                    vkGetInstanceProcAddr(VkInstance(_instance), "vkDestroyDebugReportCallbackEXT")
 				                    );
 				if(destroyFn){
-					destroyFn(_instance, _reporter_cbk, nullptr);
+					destroyFn(VkInstance(_instance), _reporter_cbk, nullptr);
 				}
 			}
 


### PR DESCRIPTION
it is very important please merge this to master too.

// 32-bit vulkan is not typesafe for handles, so don't allow copy constructors on this platform by default.
// VULKAN_HPP_TYPESAFE_CONVERSION commit

vuh/src/instance.cpp:175:16: error: no viable conversion from 'vk::Instance' to 'VkInstance_T *'
                                          destroyFn(_instance, _reporter_cbk, nullptr);

following https://github.com/KhronosGroup/Vulkan-Hpp/issues/70