### PR TITLE
lots of  changes  for enable VULKAN_HPP_NO_EXCEPTIONS

### DIFF
--- a/doc/examples/vuhAndroid/app/CMakeLists.txt
+++ b/doc/examples/vuhAndroid/app/CMakeLists.txt
@@ -28,6 +28,11 @@ set_target_properties(vulkan PROPERTIES IMPORTED_LOCATION ${Vulkan_LIBRARIES})
 # do'nt define VULKAN_HPP_TYPESAFE_CONVERSION it's not safe on 32bits system
 # from vulkan.hpp "32-bit vulkan is not typesafe for handles, so don't allow copy constructors on this platform by default."
 add_definitions(-DVK_USE_PLATFORM_ANDROID_KHR=1)
+# from https://developer.android.com/sdk/ndk/index.html
+#  With the exception of the libraries listed above, native system libraries in the Android platform are not stable and may change in future platform versions.
+# Your applications should only make use of the stable native system libraries provided in this NDK.
+# Android do'nt enable exception
+add_definitions(-DVULKAN_HPP_NO_EXCEPTIONS=1)
 SET(VUH_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../../)
 SET(VUH_BUILD_TESTS OFF)
 SET(VUH_BUILD_DOCS OFF)

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -29,6 +29,7 @@ namespace {
 		auto device = physicalDevice.createDevice(devCI, nullptr);
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
 		result = device.result;
+		VULKAN_HPP_ASSERT(vk::Result::eSuccess == result);
 		return device.value;
 #else
 		result = vk::Result::eSuccess;
@@ -72,6 +73,7 @@ namespace {
 		auto buffers = device.allocateCommandBuffers(commandBufferAI);
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
 		result = buffers.result;
+		VULKAN_HPP_ASSERT(vk::Result::eSuccess == result);
 		if(vk::Result::eSuccess == result) {
 			return buffers.value[0];
 		}
@@ -111,9 +113,11 @@ namespace vuh {
 		auto pool = createCommandPool({vk::CommandPoolCreateFlagBits::eResetCommandBuffer
 													 , computeFamilyId});
 		_result = pool.result;
+		VULKAN_HPP_ASSERT(vk::Result::eSuccess == _result);
 		if(vk::Result::eSuccess == _result) {
 			_cmdpool_compute = pool.value;
 			_cmdbuf_compute = allocCmdBuffer(*this, _cmdpool_compute, _result);
+			VULKAN_HPP_ASSERT(vk::Result::eSuccess == _result);
 			if(vk::Result::eSuccess == _result) {
 				if (_tfr_family_id == _cmp_family_id) {
 					_cmdpool_transfer = _cmdpool_compute;
@@ -122,6 +126,7 @@ namespace vuh {
 					auto transfer = createCommandPool(
 							{vk::CommandPoolCreateFlagBits::eResetCommandBuffer, _tfr_family_id});
 					_result = transfer.result;
+					VULKAN_HPP_ASSERT(vk::Result::eSuccess == _result);
 					if (vk::Result::eSuccess == _result) {
 						_cmdpool_transfer = transfer.value;
 						_cmdbuf_transfer = allocCmdBuffer(*this, _cmdpool_transfer, _result);
@@ -129,6 +134,7 @@ namespace vuh {
 				}
 			}
 		}
+		VULKAN_HPP_ASSERT(vk::Result::eSuccess == _result);
 		if(vk::Result::eSuccess != _result) {
 			release(); // because vk::Device does not know how to clean after itself
 		}
@@ -276,6 +282,7 @@ namespace vuh {
 		auto pipeline = createComputePipeline(pipe_cache, pipelineCI, nullptr);
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
 		result = pipeline.result;
+		VULKAN_HPP_ASSERT(vk::Result::eSuccess == result);
 		return pipeline.value;
 #else
 		result = vk::Result::eSuccess;
@@ -308,6 +315,7 @@ namespace vuh {
 	   auto allocMem = allocateMemory(allocInfo);
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
 		result = allocMem.result;
+		VULKAN_HPP_ASSERT(vk::Result::eSuccess == result);
 		return allocMem.value;
 #else
 		result = vk::Result::eSuccess;

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -136,14 +136,14 @@ namespace vuh {
 		try {
 			_cmdpool_compute = createCommandPool({vk::CommandPoolCreateFlagBits::eResetCommandBuffer
 			                                     , computeFamilyId});
-			_cmdbuf_compute = allocCmdBuffer(*this, _cmdpool_compute);
+			_cmdbuf_compute = allocCmdBuffer(*this, _cmdpool_compute, _result);
 			if(_tfr_family_id == _cmp_family_id){
 				_cmdpool_transfer = _cmdpool_compute;
 				_cmdbuf_transfer = _cmdbuf_compute;
 			} else {
 				_cmdpool_transfer = createCommandPool(
 				                 {vk::CommandPoolCreateFlagBits::eResetCommandBuffer, _tfr_family_id});
-				_cmdbuf_transfer = allocCmdBuffer(*this, _cmdpool_transfer);
+				_cmdbuf_transfer = allocCmdBuffer(*this, _cmdpool_transfer, _result);
 			}
 		} catch(vk::Error&) {
 			release(); // because vk::Device does not know how to clean after itself

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -1,5 +1,7 @@
 #include "vuh/error.h"
 
+#ifndef VULKAN_HPP_NO_EXCEPTIONS
+
 namespace vuh {
 	/// Constructs the exception object with explanatory string.
 	NoSuitableMemoryFound::NoSuitableMemoryFound(const std::string& message)
@@ -22,3 +24,5 @@ namespace vuh {
 	{}
 
 } // namespace vuh
+
+#endif

--- a/src/include/vuh/arr/allocDevice.hpp
+++ b/src/include/vuh/arr/allocDevice.hpp
@@ -32,6 +32,7 @@ public:
 		auto buffer = device.createBuffer({ {}, size_bytes, flags_combined});
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
 		result = buffer.result;
+		VULKAN_HPP_ASSERT(vk::Result::eSuccess == result);
 		return buffer.value;
 #else
 		result = vk::Result::eSuccess;
@@ -49,6 +50,7 @@ public:
 		auto mem = vk::DeviceMemory{};
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
 		auto alloc_mem = device.allocateMemory({device.getBufferMemoryRequirements(buffer).size, _memid});
+		VULKAN_HPP_ASSERT(vk::Result::eSuccess == alloc_mem.result);
 		if (vk::Result::eSuccess == alloc_mem.result) {
 			mem = alloc_mem.value;
 		} else {
@@ -148,6 +150,7 @@ public:
 		vk::ResultValueType<vk::Buffer>::type buffer = device.createBuffer({ {}, size_bytes, flags});
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
 		result = buffer.result;
+		VULKAN_HPP_ASSERT(vk::Result::eSuccess == result);
 		return buffer.value;
 #else
 		result = vk::Result::eSuccess;

--- a/src/include/vuh/arr/basicArray.hpp
+++ b/src/include/vuh/arr/basicArray.hpp
@@ -30,6 +30,7 @@ public:
 	   , _dev(device)
    {
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
+		VULKAN_HPP_ASSERT(vk::Result::eSuccess == _result);
 		if (vk::Result::eSuccess == _result) {
 			auto alloc = Alloc();
 			_mem = alloc.allocMemory(device, *this, properties);

--- a/src/include/vuh/arr/basicArray.hpp
+++ b/src/include/vuh/arr/basicArray.hpp
@@ -26,9 +26,20 @@ public:
 	           , vk::MemoryPropertyFlags properties={} ///< additional memory property flags. These are 'added' to flags defind by allocator.
 	           , vk::BufferUsageFlags usage={}         ///< additional usage flagsws. These are 'added' to flags defined by allocator.
 	           )
-	   : vk::Buffer(Alloc::makeBuffer(device, size_bytes, descriptor_flags | usage))
+	   : vk::Buffer(Alloc::makeBuffer(device, size_bytes, descriptor_flags | usage, _result))
 	   , _dev(device)
    {
+#ifdef VULKAN_HPP_NO_EXCEPTIONS
+		if (vk::Result::eSuccess == _result) {
+			auto alloc = Alloc();
+			_mem = alloc.allocMemory(device, *this, properties);
+			_flags = alloc.memoryProperties(device);
+			_dev.bindBufferMemory(*this, _mem, 0);
+		}
+		//else {
+		//	release();
+		//}
+#else
       try{
          auto alloc = Alloc();
          _mem = alloc.allocMemory(device, *this, properties);
@@ -38,6 +49,7 @@ public:
          release();
          throw;
       }
+#endif
 	}
 
 	/// Release resources associated with current object.
@@ -101,6 +113,7 @@ protected: // data
 	vk::DeviceMemory _mem;           ///< associated chunk of device memory
 	vk::MemoryPropertyFlags _flags;  ///< actual flags of allocated memory (may differ from those requested)
 	vuh::Device& _dev;               ///< referes underlying logical device
+	vk::Result _result;
 }; // class BasicArray
 } // namespace arr
 } // namespace vuh

--- a/src/include/vuh/arr/copy_async.hpp
+++ b/src/include/vuh/arr/copy_async.hpp
@@ -21,6 +21,7 @@ namespace vuh {
 				auto buffer = device.allocateCommandBuffers(bufferAI);
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
 				result = buffer.result;
+				VULKAN_HPP_ASSERT(vk::Result::eSuccess == result);
 				if(vk::Result::eSuccess == result) {
 					cmd_buffer = buffer.value[0];
 				} else {
@@ -88,6 +89,7 @@ namespace vuh {
 				auto fen = device->createFence(vk::FenceCreateInfo());
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
 				result = fen.result;
+				VULKAN_HPP_ASSERT(vk::Result::eSuccess == result);
 				auto fence = fen.value;
 #else
 				auto fence = fen;

--- a/src/include/vuh/arr/deviceArray.hpp
+++ b/src/include/vuh/arr/deviceArray.hpp
@@ -218,12 +218,30 @@ public:
 private: // helpers
 	auto host_data()-> T* {
 		assert(Base::isHostVisible());
-		return static_cast<T*>(Base::_dev.mapMemory(Base::_mem, 0, size_bytes()));
+        auto data = Base::_dev.mapMemory(Base::_mem, 0, size_bytes());
+#ifdef VULKAN_HPP_NO_EXCEPTIONS
+        assert(vk::Result::eSuccess != data.result);
+        if (vk::Result::eSuccess == data.result) {
+            return static_cast<T *>(data.value);
+        }
+        return nullptr;
+#else
+		return static_cast<T*>(data);
+#endif
 	}
 
 	auto host_data() const-> const T* {
 		assert(Base::isHostVisible());
-		return static_cast<const T*>(Base::_dev.mapMemory(Base::_mem, 0, size_bytes()));
+        auto data = Base::_dev.mapMemory(Base::_mem, 0, size_bytes());
+#ifdef VULKAN_HPP_NO_EXCEPTIONS
+		assert(vk::Result::eSuccess != data.result);
+		if (vk::Result::eSuccess == data.result) {
+            return static_cast<const T *>(data.value);
+        }
+        return nullptr;
+#else
+        return static_cast<const T*>(data);
+#endif
 	}
 private: // data
 	size_t _size; ///< number of elements. Actual allocated memory may be a bit bigger than necessary.

--- a/src/include/vuh/arr/deviceArray.hpp
+++ b/src/include/vuh/arr/deviceArray.hpp
@@ -220,7 +220,7 @@ private: // helpers
 		assert(Base::isHostVisible());
         auto data = Base::_dev.mapMemory(Base::_mem, 0, size_bytes());
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
-        assert(vk::Result::eSuccess != data.result);
+        assert(vk::Result::eSuccess == data.result);
         if (vk::Result::eSuccess == data.result) {
             return static_cast<T *>(data.value);
         }
@@ -234,7 +234,7 @@ private: // helpers
 		assert(Base::isHostVisible());
         auto data = Base::_dev.mapMemory(Base::_mem, 0, size_bytes());
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
-		assert(vk::Result::eSuccess != data.result);
+		assert(vk::Result::eSuccess == data.result);
 		if (vk::Result::eSuccess == data.result) {
             return static_cast<const T *>(data.value);
         }

--- a/src/include/vuh/arr/deviceArray.hpp
+++ b/src/include/vuh/arr/deviceArray.hpp
@@ -220,7 +220,7 @@ private: // helpers
 		assert(Base::isHostVisible());
         auto data = Base::_dev.mapMemory(Base::_mem, 0, size_bytes());
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
-        assert(vk::Result::eSuccess == data.result);
+        VULKAN_HPP_ASSERT(vk::Result::eSuccess == data.result);
         if (vk::Result::eSuccess == data.result) {
             return static_cast<T *>(data.value);
         }
@@ -234,7 +234,7 @@ private: // helpers
 		assert(Base::isHostVisible());
         auto data = Base::_dev.mapMemory(Base::_mem, 0, size_bytes());
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
-		assert(vk::Result::eSuccess == data.result);
+        VULKAN_HPP_ASSERT(vk::Result::eSuccess == data.result);
 		if (vk::Result::eSuccess == data.result) {
             return static_cast<const T *>(data.value);
         }

--- a/src/include/vuh/arr/hostArray.hpp
+++ b/src/include/vuh/arr/hostArray.hpp
@@ -33,6 +33,7 @@ public:
 		auto data = Base::_dev.mapMemory(Base::_mem, 0, n_elements*sizeof(T));
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
 		_result = data.result;
+		VULKAN_HPP_ASSERT(vk::Result::eSuccess == _result);
 		_data = static_cast<T*>(data.value);
 #else
 		_data = static_cast<T*>(data);

--- a/src/include/vuh/arr/hostArray.hpp
+++ b/src/include/vuh/arr/hostArray.hpp
@@ -27,9 +27,17 @@ public:
 	          , vk::BufferUsageFlags flags_buffer={}    ///< additional (to defined by allocator) buffer usage flags
 	          )
 	   : BasicArray<Alloc>(device, n_elements*sizeof(T), flags_memory, flags_buffer)
-	   , _data(static_cast<T*>(Base::_dev.mapMemory(Base::_mem, 0, n_elements*sizeof(T))))
+	   , _result(vk::Result::eSuccess)
 	   , _size(n_elements)
-	{}
+	{
+		auto data = Base::_dev.mapMemory(Base::_mem, 0, n_elements*sizeof(T));
+#ifdef VULKAN_HPP_NO_EXCEPTIONS
+		_result = data.result;
+		_data = static_cast<T*>(data.value);
+#else
+		_data = static_cast<T*>(data.value);
+#endif
+	}
 
 	/// Construct array on given device and initialize with a provided value.
 	HostArray( vuh::Device& device ///< device to create array on
@@ -114,6 +122,7 @@ public:
 private: // data
    T* _data;       ///< host accessible pointer to the beginning of corresponding memory chunk.
    size_t _size;  ///< Number of elements. Actual allocated memory may be a bit bigger then necessary.
+   vk::Result _result;
 }; // class HostArray
 } // namespace arr
 } // namespace vuh

--- a/src/include/vuh/arr/hostArray.hpp
+++ b/src/include/vuh/arr/hostArray.hpp
@@ -35,7 +35,7 @@ public:
 		_result = data.result;
 		_data = static_cast<T*>(data.value);
 #else
-		_data = static_cast<T*>(data.value);
+		_data = static_cast<T*>(data);
 #endif
 	}
 

--- a/src/include/vuh/delayed.hpp
+++ b/src/include/vuh/delayed.hpp
@@ -36,6 +36,14 @@ namespace vuh {
 		   : vk::Fence(fence)
 		   , Action(std::move(action))
 		   , _device(&device)
+		   , _result(vk::Result::eSuccess)
+		{}
+
+		explicit Delayed(vk::Fence fence, vuh::Device& device,vk::Result result, Action action={})
+				: vk::Fence(fence)
+				, Action(std::move(action))
+				, _device(&device)
+				, _result(result)
 		{}
 
         explicit Delayed(vk::Fence fence, vk::Event event, vuh::Device& device, Action action={})
@@ -43,20 +51,22 @@ namespace vuh {
 				, vk::Event(event)
                 , Action(std::move(action))
                 , _device(&device)
+                , _result(vk::Result::eSuccess)
         {}
 
-		/// Constructor. Creates the fence in a signalled state.
-		explicit Delayed(vuh::Device& device, Action action={})
-		   : vk::Fence(device.createFence({vk::FenceCreateFlagBits::eSignaled}))
-		   , Action(std::move(action))
-		   , _device(&device)
+		/// Constructs for VULKAN_HPP_NO_EXCEPTIONS
+		explicit Delayed(vuh::Device& device, vk::Result result, vk::Event event, Action action={})
+				: vk::Event(event)
+				, Action(std::move(action))
+				, _device(&device)
+				, _result(result)
 		{}
 
 		/// Constructs from the object of Delayed<Noop> and inherits the state of that.
 		/// Takes over the undelying fence ownership.
 		/// Mostly substitute its own action in place of Noop.
 		explicit Delayed(Delayed<detail::Noop>&& noop, Action action={})
-		   : vk::Fence(std::move(noop)), Action(std::move(action)), _device(std::move(noop._device))
+		   : vk::Fence(std::move(noop)), Action(std::move(action)), _device(std::move(noop._device)), _result(vk::Result::eSuccess)
 		{}
 
 		/// Destructor. Blocks till the undelying fence is signalled (waits forever).
@@ -76,6 +86,7 @@ namespace vuh {
 			static_cast<vk::Fence&>(*this) = std::move(static_cast<vk::Fence&>(other));
 			static_cast<Action&>(*this) = std::move(static_cast<Action&>(other));
 			_device = std::move(other._device);
+			_result = other._result;
 			return *this;
 		}
 
@@ -91,13 +102,25 @@ namespace vuh {
 		         ) noexcept-> void
 		{
 			if(_device){
-				_device->waitForFences({*this}, true, period);
-				if(_device->getFenceStatus(*this) == vk::Result::eSuccess){
-					_device->destroyFence(*this);
-					if(bool(vk::Event(*this))) {
+				bool release = false;
+				if (bool(vk::Fence(*this))) {
+					if (vk::Result::eSuccess == _result) {
+						_device->waitForFences({*this}, true, period);
+						if (vk::Result::eSuccess == _device->getFenceStatus(*this)) {
+							_device->destroyFence(*this);
+							release = true;
+						}
+					} else {
+						_device->destroyFence(*this);
+						release = true;
+					}
+				}
+
+				if(release) {
+					if (bool(vk::Event(*this))) {
 						_device->destroyEvent(*this);
 					}
-					static_cast<Action&>(*this)(); // exercise action
+					static_cast<Action &>(*this)(); // exercise action
 					_device.release();
 				}
 			}
@@ -115,8 +138,13 @@ namespace vuh {
 			}
 			return false;
 		}
+
+		vk::Result error() const { return _result; };
+		std::string error_to_string() const { return vk::to_string(_result); };
+
 	private: // data
 		std::unique_ptr<Device, util::NoopDeleter<Device>> _device; ///< refers to the device owning corresponding the underlying fence.
+		vk::Result _result;
 	}; // class Delayed
 
 	/// Delayed No-Action. Just a synchronization point.

--- a/src/include/vuh/delayed.hpp
+++ b/src/include/vuh/delayed.hpp
@@ -62,6 +62,23 @@ namespace vuh {
 				, _result(result)
 		{}
 
+		/// Constructor. Creates the fence in a signalled state.
+		explicit Delayed(vuh::Device& device, Action action={})
+				: Action(std::move(action))
+				, _device(&device)
+				, _result(vk::Result::eSuccess)
+		{
+#ifdef VULKAN_HPP_NO_EXCEPTIONS
+		    auto fen = device.createFence({vk::FenceCreateFlagBits::eSignaled});
+		    _result = fen.result;
+		    VULKAN_HPP_ASSERT(vk::Result::eSuccess == _result);
+		    vk::Fence(*this) = fen.value;
+#else
+			vk::Fence(*this) = device.createFence({vk::FenceCreateFlagBits::eSignaled});
+#endif
+		}
+
+
 		/// Constructs from the object of Delayed<Noop> and inherits the state of that.
 		/// Takes over the undelying fence ownership.
 		/// Mostly substitute its own action in place of Noop.
@@ -140,6 +157,7 @@ namespace vuh {
 		}
 
 		vk::Result error() const { return _result; };
+		bool success() const { return vk::Result::eSuccess == _result; }
 		std::string error_to_string() const { return vk::to_string(_result); };
 
 	private: // data

--- a/src/include/vuh/device.h
+++ b/src/include/vuh/device.h
@@ -36,7 +36,7 @@ namespace vuh {
 
 		auto computeQueue(uint32_t i = 0)-> vk::Queue;
 		auto transferQueue(uint32_t i = 0)-> vk::Queue;
-		auto alloc(vk::Buffer buf, uint32_t memory_id)-> vk::DeviceMemory;
+		auto alloc(vk::Buffer buf, uint32_t memory_id, vk::Result& result)-> vk::DeviceMemory;
 		auto computeCmdPool()-> vk::CommandPool {return _cmdpool_compute;}
 		auto computeCmdBuffer()-> vk::CommandBuffer& {return _cmdbuf_compute;}
 		auto transferCmdPool()-> vk::CommandPool;
@@ -44,10 +44,11 @@ namespace vuh {
 		auto createPipeline(vk::PipelineLayout pipe_layout
 		                    , vk::PipelineCache pipe_cache
 		                    , const vk::PipelineShaderStageCreateInfo& shader_stage_info
+							, vk::Result& result
 		                    , vk::PipelineCreateFlags flags={}
 		                    )-> vk::Pipeline;
 		auto instance()-> vuh::Instance& { return _instance; }
-		auto releaseComputeCmdBuffer()-> vk::CommandBuffer;
+		auto releaseComputeCmdBuffer(vk::Result& result)-> vk::CommandBuffer;
 		
 	private: // helpers
 		explicit Device(vuh::Instance& instance, vk::PhysicalDevice physdevice
@@ -64,5 +65,6 @@ namespace vuh {
 		vk::CommandBuffer  _cmdbuf_transfer;    ///< primary command buffer associated with transfer command pool. Initialized on first transfer request.
 		uint32_t _cmp_family_id = uint32_t(-1); ///< compute queue family id. -1 if device does not have compute-capable queues.
 		uint32_t _tfr_family_id = uint32_t(-1); ///< transfer queue family id, maybe the same as compute queue id.
+		vk::Result	_result;
 	}; // class Device
 }

--- a/src/include/vuh/error.h
+++ b/src/include/vuh/error.h
@@ -2,6 +2,8 @@
 
 #include <vulkan/vulkan.hpp>
 
+#ifndef VULKAN_HPP_NO_EXCEPTIONS
+
 namespace vuh {
 	/// Exception indicating that memory with requested properties
 	/// has not been found on a device.
@@ -18,3 +20,5 @@ namespace vuh {
 		FileReadFailure(const char* message);
 	};
 } // namespace vuh
+
+#endif

--- a/src/include/vuh/instance.h
+++ b/src/include/vuh/instance.h
@@ -38,11 +38,19 @@ namespace vuh {
 		auto devices()-> std::vector<vuh::Device>;
 		auto report(const char* prefix, const char* message
 		            , VkDebugReportFlagsEXT flags=VK_DEBUG_REPORT_INFORMATION_BIT_EXT) const-> void;
+
+		explicit operator bool() const;
+		bool operator!() const;
+
+		vk::Result error() const;
+		std::string error_to_string() const;
+
 	private: // helpers
 		auto clear() noexcept-> void;
 	private: // data
 		vk::Instance _instance;     ///< vulkan instance
 		debug_reporter_t _reporter; ///< points to actual reporting function. This pointer is registered with a reporter callback but can also be used directly.
 		VkDebugReportCallbackEXT _reporter_cbk; ///< report callback. Only used to release the handle in the end.
+		vk::Result	_result;
 	}; // class Instance
 } // namespace vuh

--- a/src/include/vuh/program.hpp
+++ b/src/include/vuh/program.hpp
@@ -138,6 +138,7 @@ namespace vuh {
 						auto ev = _device.createEvent(vk::EventCreateInfo());
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
 						res = ev.result;
+						VULKAN_HPP_ASSERT(vk::Result::eSuccess == res);
 						event = ev.value;
 #else
 						event = ev;
@@ -157,6 +158,7 @@ namespace vuh {
 								vk::FenceCreateInfo()); // fence makes sure the control is not returned to CPU till command buffer is depleted
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
 						res = fen.result;
+						VULKAN_HPP_ASSERT(vk::Result::eSuccess == res);
 						auto fence = fen.value;
 #else
 						auto fence = fen;
@@ -201,6 +203,7 @@ namespace vuh {
 														 });
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
 				_result = shader.result;
+				VULKAN_HPP_ASSERT(vk::Result::eSuccess == _result);
 				_shader = shader.value;
 #else
 				_shader = shader;
@@ -273,6 +276,7 @@ namespace vuh {
 				                                       });
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
 				_result = layout.result;
+				VULKAN_HPP_ASSERT(vk::Result::eSuccess == _result);
 				_dsclayout = layout.value;
 #else
 				_dsclayout = layout;
@@ -281,6 +285,7 @@ namespace vuh {
 					auto pipe_cache = _device.createPipelineCache({});
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
 					_result = pipe_cache.result;
+					VULKAN_HPP_ASSERT(vk::Result::eSuccess == _result);
 					_pipecache = pipe_cache.value;
 #else
 					_pipecache = pipe_cache;
@@ -292,6 +297,7 @@ namespace vuh {
 							 psrange.data()});
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
 					_result = pipe_layout.result;
+					VULKAN_HPP_ASSERT(vk::Result::eSuccess == _result);
 					_pipelayout = pipe_layout.value;
 #else
 					_pipelayout = pipe_layout;
@@ -313,6 +319,7 @@ namespace vuh {
 				_result = vk::Result::eSuccess;
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
 				_result = pool.result;
+				VULKAN_HPP_ASSERT(vk::Result::eSuccess == _result);
 				_dscpool = pool.value;
 #else
 				_dscpool = pool;
@@ -321,6 +328,7 @@ namespace vuh {
 					auto desc_set = _device.allocateDescriptorSets({_dscpool, 1, &_dsclayout});
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
 					_result = pool.result;
+					VULKAN_HPP_ASSERT(vk::Result::eSuccess == _result);
 					_dscset = desc_set.value[0];
 #else
 					_dscset = desc_set[0];

--- a/src/include/vuh/program.hpp
+++ b/src/include/vuh/program.hpp
@@ -286,7 +286,7 @@ namespace vuh {
 					_pipecache = pipe_cache;
 #endif
 				}
-				if(bool(_pipelayout)) {
+				if(bool(_pipecache)) {
 					auto pipe_layout = _device.createPipelineLayout(
 							{vk::PipelineLayoutCreateFlags(), 1, &_dsclayout, uint32_t(N),
 							 psrange.data()});

--- a/src/instance.cpp
+++ b/src/instance.cpp
@@ -54,6 +54,7 @@ namespace {
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
         const auto em_layers = vk::enumerateInstanceLayerProperties();
         auto avail_layers = em_layers.value;
+        VULKAN_HPP_ASSERT(vk::Result::eSuccess == em_layers.result);
         if(vk::Result::eSuccess != em_layers.result) {
             avail_layers.clear();
         }
@@ -73,6 +74,7 @@ namespace {
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
         const auto em_extensions = vk::enumerateInstanceExtensionProperties();
         auto avail_extensions = em_extensions.value;
+        VULKAN_HPP_ASSERT(vk::Result::eSuccess == em_extensions.result);
         if(vk::Result::eSuccess != em_extensions.result) {
             avail_extensions.clear();
         }
@@ -110,6 +112,7 @@ namespace {
 		auto instance = vk::createInstance(createInfo);
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
         result = instance.result;
+        VULKAN_HPP_ASSERT(vk::Result::eSuccess == result);
         return instance.value;
 #else
         result = vk::Result::eSuccess;
@@ -209,6 +212,7 @@ namespace vuh {
 		auto devs = _instance.enumeratePhysicalDevices();
 #ifdef VULKAN_HPP_NO_EXCEPTIONS
         _result = devs.result;
+        VULKAN_HPP_ASSERT(vk::Result::eSuccess == _result);
         auto physdevs = devs.value;
 #else
         _result = vk::Result::eSuccess;

--- a/src/instance.cpp
+++ b/src/instance.cpp
@@ -51,7 +51,15 @@ namespace {
 	/// Filter requested layers, throw away those not present on particular instance.
 	/// Add default validation layers to debug build.
 	auto filter_layers(const std::vector<const char*>& layers) {
+#ifdef VULKAN_HPP_NO_EXCEPTIONS
+        const auto em_layers = vk::enumerateInstanceLayerProperties();
+        auto avail_layers = em_layers.value;
+        if(vk::Result::eSuccess != em_layers.result) {
+            avail_layers.clear();
+        }
+#else
 		const auto avail_layers = vk::enumerateInstanceLayerProperties();
+#endif
 		auto r = filter_list({}, layers, avail_layers
 		                     , [](const auto& l){return l.layerName;});
 		r = filter_list(std::move(r), default_layers, avail_layers
@@ -62,7 +70,15 @@ namespace {
 	/// Filter requested extensions, throw away those not present on particular instance.
 	/// Add default debug extensions to debug build.
 	auto filter_extensions(const std::vector<const char*>& extensions) {
+#ifdef VULKAN_HPP_NO_EXCEPTIONS
+        const auto em_extensions = vk::enumerateInstanceExtensionProperties();
+        auto avail_extensions = em_extensions.value;
+        if(vk::Result::eSuccess != em_extensions.result) {
+            avail_extensions.clear();
+        }
+#else
 		const auto avail_extensions = vk::enumerateInstanceExtensionProperties();
+#endif
 		auto r = filter_list({}, extensions, avail_extensions
 		                     , [](const auto& l){return l.extensionName;});
 		r = filter_list(std::move(r), default_extensions, avail_extensions
@@ -86,11 +102,19 @@ namespace {
 	auto createInstance(const std::vector<const char*> layers
 	                   , const std::vector<const char*> extensions
 	                   , const vk::ApplicationInfo& info
+	                   , vk::Result& result
 	                   )-> vk::Instance
 	{
 		auto createInfo = vk::InstanceCreateInfo(vk::InstanceCreateFlags(), &info
 		                                         , ARR_VIEW(layers), ARR_VIEW(extensions));
-		return vk::createInstance(createInfo);
+		auto instance = vk::createInstance(createInfo);
+#ifdef VULKAN_HPP_NO_EXCEPTIONS
+        result = instance.result;
+        return instance.value;
+#else
+        result = vk::Result::eSuccess;
+		return instance;
+#endif
 	}
 
 	/// Register a callback function for the extension VK_EXT_DEBUG_REPORT_EXTENSION_NAME,
@@ -131,7 +155,7 @@ namespace vuh {
 	                   , debug_reporter_flags_t report_flags
 					   , void* report_userdata
 	                   )
-	   : _instance(createInstance(filter_layers(layers), filter_extensions(extension), info))
+	   : _instance(createInstance(filter_layers(layers), filter_extensions(extension), info, _result))
 	   , _reporter(report_callback ? report_callback : debugReporter)
 	   , _reporter_cbk(registerReporter(_instance, _reporter,report_flags,report_userdata))
 	{}
@@ -182,11 +206,20 @@ namespace vuh {
 
 	/// @return vector of available vulkan devices
 	auto Instance::devices()-> std::vector<Device> {
-		auto physdevs = _instance.enumeratePhysicalDevices();
+		auto devs = _instance.enumeratePhysicalDevices();
+#ifdef VULKAN_HPP_NO_EXCEPTIONS
+        _result = devs.result;
+        auto physdevs = devs.value;
+#else
+        _result = vk::Result::eSuccess;
+        auto physdevs = devs;
+#endif
 		auto r = std::vector<Device>{};
-		for(auto pd: physdevs){
-			r.emplace_back(*this, pd);
-		}
+		if (vk::Result::eSuccess == _result) {
+            for (auto pd: physdevs) {
+                r.emplace_back(*this, pd);
+            }
+        }
 		return r;
 	}
 
@@ -198,5 +231,21 @@ namespace vuh {
 	                      ) const-> void
 	{
 		_reporter(flags, VkDebugReportObjectTypeEXT{}, 0, 0, 0 , prefix, message, nullptr);
+	}
+
+	Instance::operator bool() const {
+		return bool(_instance);
+	}
+
+	bool Instance::operator!() const {
+		return !_instance;
+	}
+
+	vk::Result Instance::error() const {
+		return _result;
+	}
+
+	std::string Instance::error_to_string() const {
+		return vk::to_string(_result);
 	}
 } // namespace vuh

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -10,7 +10,12 @@ namespace vuh {
 	auto read_spirv(const char* filename)-> std::vector<char> {
 		auto fin = std::ifstream(filename, std::ios::binary);
 		if(!fin.is_open()){
+#ifdef VULKAN_HPP_NO_EXCEPTIONS
+			VULKAN_HPP_ASSERT(0);
+			return std::vector<char>();
+#else
 			throw FileReadFailure(std::string("could not open file ") + filename + " for reading");
+#endif
 		}
 		auto ret = std::vector<char>(std::istreambuf_iterator<char>(fin), std::istreambuf_iterator<char>());
 


### PR DESCRIPTION
lots of  changes  for enable VULKAN_HPP_NO_EXCEPTIONS 

android does not support c++ exception well, lots of versions will crash when exception  is throw

try catch will failed. we default disable exception on android. 

LOCAL_CPPFLAGS := -fexceptions works incorrect.

following https://developer.android.com/ndk/guides/cpp-support