### PR TITLE
silence 'ambiguous' warnings

### DIFF
--- a/src/device.cpp
+++ b/src/device.cpp
@@ -110,10 +110,10 @@ namespace vuh {
 	auto Device::release() noexcept-> void {
 		if(static_cast<vk::Device&>(*this)){
 			if(_tfr_family_id != _cmp_family_id){
-				freeCommandBuffers(_cmdpool_transfer, 1, &_cmdbuf_transfer);
+				freeCommandBuffers(_cmdpool_transfer, _cmdbuf_transfer);
 				destroyCommandPool(_cmdpool_transfer);
 			}
-			freeCommandBuffers(_cmdpool_compute, 1, &_cmdbuf_compute);
+			freeCommandBuffers(_cmdpool_compute, _cmdbuf_compute);
 			destroyCommandPool(_cmdpool_compute);
 
 			vk::Device::destroy();

--- a/src/include/vuh/arr/copy_async.hpp
+++ b/src/include/vuh/arr/copy_async.hpp
@@ -30,7 +30,7 @@ namespace vuh {
 			/// Release the buffer resources
 			auto release() noexcept-> void {
 				if(device){
-					device->freeCommandBuffers(device->transferCmdPool(), 1, &cmd_buffer);
+					device->freeCommandBuffers(device->transferCmdPool(), cmd_buffer);
 				}
 			}
 		public: // data

--- a/src/include/vuh/program.hpp
+++ b/src/include/vuh/program.hpp
@@ -84,7 +84,7 @@ namespace vuh {
 			/// Buffer is released from device's compute command pool.
 			auto release() noexcept-> void {
 				if(device){
-					device->freeCommandBuffers(device->computeCmdPool(), 1, &cmd_buffer);
+					device->freeCommandBuffers(device->computeCmdPool(), cmd_buffer);
 				}
 			}
 		public: // data

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -33,7 +33,7 @@ namespace arr {
 		auto cmd_buf = device.transferCmdBuffer();
 		cmd_buf.begin({vk::CommandBufferUsageFlagBits::eOneTimeSubmit});
 		auto region = vk::BufferCopy(src_offset, dst_offset, size_bytes);
-		cmd_buf.copyBuffer(src, dst, 1, &region);
+		cmd_buf.copyBuffer(src, dst, region);
 		cmd_buf.end();
 		auto queue = device.transferQueue();
 		auto submit_info = vk::SubmitInfo(0, nullptr, nullptr, 1, &cmd_buf);


### PR DESCRIPTION
On my system it complains like

    In file included from D:/home/src/vuh/build/windows/install/include/vuh/array.hpp:6,
                 from D:/home/src/vuh/build/windows/install/include/vuh/program.hpp:3,
                 from D:/home/src/vuh/build/windows/install/include/vuh/vuh.h:6,
                 from example.cpp:4:
    D:/home/src/vuh/build/windows/install/include/vuh/arr/copy_async.hpp: In member function 'void vuh::detail::_CmdBuffer::release()':
    D:/home/src/vuh/build/windows/install/include/vuh/arr/copy_async.hpp:33:74: warning: ISO C++ says that these are ambiguous, even though the worst conversion for the first is better than the worst conversion for the second:
       33 |      device->freeCommandBuffers(device->transferCmdPool(), 1, &cmd_buffer);
          |                                                                          ^
    In file included from D:/home/src/vuh/build/windows/install/include/vuh/device.h:3,
                 from D:/home/src/vuh/build/windows/install/include/vuh/vuh.h:3,
                 from example.cpp:4:
    D:/dev/msys64/mingw64/include/vulkan/vulkan.hpp:77628:26: note: candidate 1: 'void vk::Device::freeCommandBuffers(vk::CommandPool, uint32_t, const vk::CommandBuffer*, const Dispatch&) const [with Dispatch = vk::DispatchLoaderStatic; uint32_t = unsigned int]'
    77628 |   VULKAN_HPP_INLINE void Device::freeCommandBuffers( VULKAN_HPP_NAMESPACE::CommandPool commandPool, uint32_t commandBufferCount, const VULKAN_HPP_NAMESPACE::CommandBuffer* pCommandBuffers, Dispatch const &d) const VULKAN_HPP_NOEXCEPT
          |                          ^~~~~~
    D:/dev/msys64/mingw64/include/vulkan/vulkan.hpp:77634:26: note: candidate 2: 'void vk::Device::freeCommandBuffers(vk::CommandPool, vk::ArrayProxy<const vk::CommandBuffer>, const Dispatch&) const [with Dispatch = vk::CommandBuffer*]'
    77634 |   VULKAN_HPP_INLINE void Device::freeCommandBuffers( VULKAN_HPP_NAMESPACE::CommandPool commandPool, ArrayProxy<const VULKAN_HPP_NAMESPACE::CommandBuffer> commandBuffers, Dispatch const &d ) const VULKAN_HPP_NOEXCEPT
          |                          ^~~~~~

since it somehow manages to convert the constant 1 to an ArrayProxy (I don't understand how).  However, since a CommandBuffer is implicitely convertable to an ArrayProxy via

    ArrayProxy( T & value ) VULKAN_HPP_NOEXCEPT
      : m_count( 1 )
      , m_ptr( &value )
    {}

it is easy to change in a way that makes the overload unique.