### PR TITLE
allow to read SPIR-V from code segment

### DIFF
--- a/src/include/vuh/program.hpp
+++ b/src/include/vuh/program.hpp
@@ -147,11 +147,19 @@ namespace vuh {
 			            , const std::vector<char>& code  ///< actual binary SPIR-V shader code
 			            , vk::ShaderModuleCreateFlags flags={}
 			            )
-			   : _device(device)
+				: ProgramBase(device, uint32_t(code.size()),
+				              reinterpret_cast<const uint32_t*>(code.data()))
+			{}
+
+			/// Construct object using given a vuh::Device a SPIR-V shader code as plain array.
+			ProgramBase(vuh::Device& device              ///< device used to run the code
+			            , uint32_t size                  ///< size of binary shader code
+			            , const uint32_t* code           ///< actual binary SPIR-V shader code
+			            , vk::ShaderModuleCreateFlags flags={}
+			            )
+				: _device(device)
 			{
-				_shader = device.createShaderModule({ flags, uint32_t(code.size())
-				                                    , reinterpret_cast<const uint32_t*>(code.data())
-				                                    });
+				_shader = device.createShaderModule({ flags, size, code });
 			}
 
 			/// Destroy the object and release associated resources.
@@ -304,6 +312,11 @@ namespace vuh {
 			   : ProgramBase(device, code, f)
 			{}
 
+			/// Construct object using given a vuh::Device a SPIR-V shader code in plain array.
+			SpecsBase(Device& device, uint32_t size, const uint32_t* code, vk::ShaderModuleCreateFlags f={})
+			   : ProgramBase(device, size, code, f)
+			{}
+
 			/// Initialize the pipeline.
 			/// Specialization constants interface is defined here.
 			auto init_pipeline()-> void {
@@ -333,6 +346,11 @@ namespace vuh {
 			/// Construct object using given a vuh::Device a SPIR-V shader code.
 			SpecsBase(Device& device, const std::vector<char>& code, vk::ShaderModuleCreateFlags f={})
 			   : ProgramBase(device, code, f)
+			{}
+
+			/// Construct object using given a vuh::Device a SPIR-V shader code in plain array.
+			SpecsBase(Device& device, uint32_t size, const uint32_t* code, vk::ShaderModuleCreateFlags f={})
+			   : ProgramBase(device, size, code, f)
 			{}
 
 			/// Initialize the pipeline with empty specialialization constants interface.
@@ -370,6 +388,13 @@ namespace vuh {
 		        , vk::ShaderModuleCreateFlags flags={}
 		        )
 		   : Base(device, code, flags)
+		{}
+
+		/// Initialize program on a device from binary SPIR-V code in plain array
+		Program(vuh::Device& device, uint32_t size, const uint32_t* code
+		        , vk::ShaderModuleCreateFlags flags={}
+		        )
+		   : Base(device, size, code, flags)
 		{}
 
 		using Base::run;


### PR DESCRIPTION
I like to "compile" the spv files to C header files using `xxd -i` which gives me something like

    /* shader.spv.h */
    alignas(4) const unsigned char shader_spv[] = {
        0x4a, 0x01, /* ... */, 0x55
    };

with the content of the spv file as plain C array which will be stored in the read-only "code section" of the linked program.  Unfortunatelly, it seems to be impossible to get that array into a `vector<char>` without unnecessary allocations and copying it unnecessarily around.  For this reason, I added the `uint32_t size, const uint32_t* code` constructor to the `Program` class.  I'm not sure, this is the best solution to the problem but it is the one I can offer as pull request.

The "correct" way would be probably to use a `std::span` instead of a `std::vector` but which is only available in C++20.  Another possibility would be probably to allow the user to construct their own `ShaderModule` and pass it as parameter to the constructor of `Program`.  Variations to the approach in this pull request would be to use a different data type for the size (e.g. `int` or `size_t`) and/or code (e.g. `uint8_t` or `char`).  For no particular reason I used the types (`uint32_t` and `const uint32_t*`) suggested by Vulkan-API.