### PR TITLE
Fixes for data types

### DIFF
--- a/src/device.cpp
+++ b/src/device.cpp
@@ -1,7 +1,7 @@
 #include <vuh/device.h>
 
 #include <cassert>
-#include <cstdint>
+#include <stdint.h>
 #include <limits>
 
 namespace {

--- a/src/include/vuh/arr/arrayIter.hpp
+++ b/src/include/vuh/arr/arrayIter.hpp
@@ -5,7 +5,7 @@
 #include <vulkan/vulkan.hpp>
 
 #include <cassert>
-#include <cstdint>
+#include <stdint.h>
 
 namespace vuh {
 	/// Iterator to use in device-side copying and kernel calls.

--- a/src/include/vuh/program.hpp
+++ b/src/include/vuh/program.hpp
@@ -8,7 +8,7 @@
 #include <vulkan/vulkan.hpp>
 
 #include <array>
-#include <cstddef>
+#include <stdint.h>
 #include <tuple>
 #include <utility>
 
@@ -147,13 +147,13 @@ namespace vuh {
 			            , const std::vector<char>& code  ///< actual binary SPIR-V shader code
 			            , vk::ShaderModuleCreateFlags flags={}
 			            )
-				: ProgramBase(device, uint32_t(code.size()),
+				: ProgramBase(device, code.size(),
 				              reinterpret_cast<const uint32_t*>(code.data()))
 			{}
 
 			/// Construct object using given a vuh::Device a SPIR-V shader code as plain array.
 			ProgramBase(vuh::Device& device              ///< device used to run the code
-			            , uint32_t size                  ///< size of binary shader code
+			            , size_t size                    ///< size of binary shader code
 			            , const uint32_t* code           ///< actual binary SPIR-V shader code
 			            , vk::ShaderModuleCreateFlags flags={}
 			            )
@@ -313,7 +313,7 @@ namespace vuh {
 			{}
 
 			/// Construct object using given a vuh::Device a SPIR-V shader code in plain array.
-			SpecsBase(Device& device, uint32_t size, const uint32_t* code, vk::ShaderModuleCreateFlags f={})
+			SpecsBase(Device& device, size_t size, const uint32_t* code, vk::ShaderModuleCreateFlags f={})
 			   : ProgramBase(device, size, code, f)
 			{}
 
@@ -349,7 +349,7 @@ namespace vuh {
 			{}
 
 			/// Construct object using given a vuh::Device a SPIR-V shader code in plain array.
-			SpecsBase(Device& device, uint32_t size, const uint32_t* code, vk::ShaderModuleCreateFlags f={})
+			SpecsBase(Device& device, size_t size, const uint32_t* code, vk::ShaderModuleCreateFlags f={})
 			   : ProgramBase(device, size, code, f)
 			{}
 
@@ -391,7 +391,7 @@ namespace vuh {
 		{}
 
 		/// Initialize program on a device from binary SPIR-V code in plain array
-		Program(vuh::Device& device, uint32_t size, const uint32_t* code
+		Program(vuh::Device& device, size_t size, const uint32_t* code
 		        , vk::ShaderModuleCreateFlags flags={}
 		        )
 		   : Base(device, size, code, flags)
@@ -492,7 +492,7 @@ namespace vuh {
 		{}
 
 		/// Initialize program on a device from binary SPIR-V code in plain array
-		Program(vuh::Device& device, uint32_t size, const uint32_t* code
+		Program(vuh::Device& device, size_t size, const uint32_t* code
 		        , vk::ShaderModuleCreateFlags flags={}
 		        )
 		   : Base(device, size, code, flags)

--- a/src/include/vuh/program.hpp
+++ b/src/include/vuh/program.hpp
@@ -143,12 +143,11 @@ namespace vuh {
 			{}
 
 			/// Construct object using given a vuh::Device a SPIR-V shader code.
-			ProgramBase(vuh::Device& device              ///< device used to run the code
-			            , const std::vector<char>& code  ///< actual binary SPIR-V shader code
+			ProgramBase(vuh::Device& device                  ///< device used to run the code
+			            , const std::vector<uint32_t>& code  ///< actual binary SPIR-V shader code
 			            , vk::ShaderModuleCreateFlags flags={}
 			            )
-				: ProgramBase(device, code.size(),
-				              reinterpret_cast<const uint32_t*>(code.data()))
+				: ProgramBase(device, sizeof(uint32_t) * code.size(), code.data())
 			{}
 
 			/// Construct object using given a vuh::Device a SPIR-V shader code as plain array.
@@ -308,7 +307,7 @@ namespace vuh {
 			{}
 
 			/// Construct object using given a vuh::Device a SPIR-V shader code.
-			SpecsBase(Device& device, const std::vector<char>& code, vk::ShaderModuleCreateFlags f={})
+			SpecsBase(Device& device, const std::vector<uint32_t>& code, vk::ShaderModuleCreateFlags f={})
 			   : ProgramBase(device, code, f)
 			{}
 
@@ -344,7 +343,7 @@ namespace vuh {
 			{}
 
 			/// Construct object using given a vuh::Device a SPIR-V shader code.
-			SpecsBase(Device& device, const std::vector<char>& code, vk::ShaderModuleCreateFlags f={})
+			SpecsBase(Device& device, const std::vector<uint32_t>& code, vk::ShaderModuleCreateFlags f={})
 			   : ProgramBase(device, code, f)
 			{}
 
@@ -384,7 +383,7 @@ namespace vuh {
 		{}
 
 		/// Initialize program on a device from binary SPIR-V code
-		Program(vuh::Device& device, const std::vector<char>& code
+		Program(vuh::Device& device, const std::vector<uint32_t>& code
 		        , vk::ShaderModuleCreateFlags flags={}
 		        )
 		   : Base(device, code, flags)
@@ -485,7 +484,7 @@ namespace vuh {
 		{}
 
 		/// Initialize program on a device from binary SPIR-V code
-		Program(vuh::Device& device, const std::vector<char>& code
+		Program(vuh::Device& device, const std::vector<uint32_t>& code
 		        , vk::ShaderModuleCreateFlags flags={}
 		        )
 		   : Base (device, code, flags)

--- a/src/include/vuh/program.hpp
+++ b/src/include/vuh/program.hpp
@@ -491,6 +491,13 @@ namespace vuh {
 		   : Base (device, code, flags)
 		{}
 
+		/// Initialize program on a device from binary SPIR-V code in plain array
+		Program(vuh::Device& device, uint32_t size, const uint32_t* code
+		        , vk::ShaderModuleCreateFlags flags={}
+		        )
+		   : Base(device, size, code, flags)
+		{}
+
 		using Base::run;
 		using Base::run_async;
 

--- a/src/include/vuh/utils.h
+++ b/src/include/vuh/utils.h
@@ -10,6 +10,6 @@ namespace vuh {
 	/// @return nearest integer bigger or equal to exact division value
 	inline auto div_up(uint32_t x, uint32_t y){ return (x + y - 1u)/y; }
 
-	auto read_spirv(const char* filename)-> std::vector<char>;
+	auto read_spirv(const char* filename)-> std::vector<uint32_t>;
 
 } // namespace vuh

--- a/src/include/vuh/utils.h
+++ b/src/include/vuh/utils.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <cstdint>
+#include <stdint.h>
 #include <vector>
 
 namespace vuh {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -3,19 +3,28 @@
 #include <vuh/arr/arrayUtils.h>
 
 #include <fstream>
+#include <iterator>
 
 namespace vuh {
+	struct UInt32 {
+		uint32_t v;
+
+		operator uint32_t () const {
+			return v;
+		}
+	};
+
+	std::istream & operator >> (std::istream & is, UInt32 v) {
+		return is.read(reinterpret_cast<char *>(&v.v), sizeof v.v);
+	}
+
 	/// Read binary shader file into array of uint32_t. little endian assumed.
-	/// Padded by 0s to a boundary of 4.
-	auto read_spirv(const char* filename)-> std::vector<char> {
+	auto read_spirv(const char* filename)-> std::vector<uint32_t> {
 		auto fin = std::ifstream(filename, std::ios::binary);
 		if(!fin.is_open()){
 			throw FileReadFailure(std::string("could not open file ") + filename + " for reading");
 		}
-		auto ret = std::vector<char>(std::istreambuf_iterator<char>(fin), std::istreambuf_iterator<char>());
-
-		ret.resize(4u*div_up(uint32_t(ret.size()), 4u));
-		return ret;
+		return std::vector<uint32_t>(std::istream_iterator<UInt32>(fin), std::istream_iterator<UInt32>());
 	}
 
 namespace arr {


### PR DESCRIPTION
Here are some fixes:
- add the missing constructor for uint32_t-array SPIR-V
- fix the uint32_t -> size_t type for SPIR-V code size
- fix the vector<char> -> vector<uint32_t> type for code read from a file
- change include <cstdint> to <stdint.h> to have the datatypes (like uint32_t and size_t) garanteed to be available in global namespace