### PR TITLE
allow uint32_t spirv[] arrays for shader creation

### DIFF
--- a/src/include/vuh/kernel.hpp
+++ b/src/include/vuh/kernel.hpp
@@ -156,8 +156,11 @@ private: // data
 ///
 class Kernel {
 public:
-	explicit Kernel( Device& device, std::string_view source
-	               , std::string entry_point="main", VkShaderModuleCreateFlags flags={});
+	Kernel( Device& device, std::string_view source // source file name
+	      , std::string entry_point="main", VkShaderModuleCreateFlags flags={});
+
+	Kernel( Device& device, size_t byte_size, const uint32_t source[] // source code array
+	      , std::string entry_point="main", VkShaderModuleCreateFlags flags={});
 
 	~Kernel() noexcept;
 

--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -23,8 +23,28 @@ Kernel::Kernel( Device& device
 	const auto create_info = VkShaderModuleCreateInfo {
 	                         VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO, nullptr
 	                         , flags
-                             , code.size()*sizeof(decltype(code)::value_type) // byte size
+	                         , code.size()*sizeof(decltype(code)::value_type) // byte size
 	                         , code.data() };
+	VUH_CHECK(vkCreateShaderModule(device, &create_info, nullptr, &_module));
+}
+
+///
+Kernel::Kernel( Device& device
+              , size_t byte_size
+              , const uint32_t source[]
+              , std::string entry_point
+              , VkShaderModuleCreateFlags flags)
+   : _entry_point(std::move(entry_point))
+   , _cmdbuf{nullptr}
+   , _cmdpool{nullptr}
+   , _pipeline{nullptr}
+   , _device{device}
+{
+	const auto create_info = VkShaderModuleCreateInfo {
+	                         VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO, nullptr
+	                         , flags
+	                         , byte_size
+	                         , source };
 	VUH_CHECK(vkCreateShaderModule(device, &create_info, nullptr, &_module));
 }
 


### PR DESCRIPTION
Same as before for master.

Allow to create shaders directly from uint32_t arrays.