### PR TITLE
Fix compiler errors on newer vulkan implementations

### DIFF
--- a/src/device.cpp
+++ b/src/device.cpp
@@ -218,8 +218,10 @@ namespace vuh {
 	{
 		auto pipelineCI = vk::ComputePipelineCreateInfo(flags
 																		, shader_stage_info, pipe_layout);
-		return createComputePipeline(pipe_cache, pipelineCI, nullptr);
-		
+		auto maybePipeline = createComputePipeline(pipe_cache, pipelineCI, nullptr);
+
+		assert(maybePipeline.result == vk::Result::eSuccess); //FIXME: should we throw here?
+		return maybePipeline.value;
 	}
 
 	/// Detach the current compute command buffer for sync operations and create the new one.

--- a/src/include/vuh/delayed.hpp
+++ b/src/include/vuh/delayed.hpp
@@ -5,6 +5,7 @@
 #include <vuh/resource.hpp>
 
 #include <cassert>
+#include <memory>
 
 namespace vuh {
 	namespace detail{


### PR DESCRIPTION
Hey there,
I was interested in using this library but found out that it didn't compile on my Arch machine with newest version of everything.

There were two errors:

1. `delayed.hpp:96:22: error: ‘unique_ptr’ in namespace ‘std’ does not name a template type`: This is simply fixed by including `<memory>`
3. `
device.cpp: In member function ‘vk::Pipeline vuh::Device::createPipeline(vk::PipelineLayout, vk::PipelineCache, const vk::PipelineShaderStageCreateInfo&, vk::PipelineCreateFlags)’:
/home/weckyy702/Documents/dev/vuh/src/device.cpp:221:45: error: could not convert ‘((vuh::Device*)this)->vuh::Device::<anonymous>.vk::Device::createComputePipeline<>(pipe_cache, pipelineCI, vk::Optional<const vk::AllocationCallbacks>(nullptr), (*(const vk::DispatchLoaderStatic*)(& vk::getDispatchLoaderStatic())))’ from ‘vk::ResultValue<vk::Pipeline>’ to ‘vk::Pipeline’`: With this one, createComputePipeline returns a ResultValue that must be unwrapped first. I used an assert here, but there is likely a better way to handle the possible error. I'd appreciate feedback on that, thanks.